### PR TITLE
Add support for non-unicode LDAP instances

### DIFF
--- a/synapse_ldap_password_provider.py
+++ b/synapse_ldap_password_provider.py
@@ -28,6 +28,14 @@ try:
         LDAP_AUTH_SIMPLE = ldap3.AUTH_SIMPLE
     except AttributeError:
         LDAP_AUTH_SIMPLE = ldap3.SIMPLE
+
+    try:
+        ldap3.set_config_parameter('DEFAULT_ENCODING', 'UTF-8')
+    except AttributeError:
+        pass
+    except ldap3.core.exceptions.LDAPConfigurationParameterError:
+        pass
+
 except ImportError:
     ldap3 = None
     pass


### PR DESCRIPTION
If you have non-unicode instance of LDAP there can be some issues.

```
2017-06-02 16:10:55,915 - synapse_ldap_password_provider - 96 - DEBUG - POST-299- LDAP connection with ldap://bbgroup.local
2017-06-02 16:10:55,915 - synapse_ldap_password_provider - 421 - DEBUG - POST-299- LDAP connection in search mode: ldap://bbgroup.local:389 - cleartext - user: jabber_user@bbgroup.local - not lazy - unbound - closed - <no socket> - tls not started - not listening - SyncStrategy - internal decoder
2017-06-02 16:11:02,414 - synapse_ldap_password_provider - 96 - DEBUG - POST-300- LDAP connection with ldap://bbgroup.local
2017-06-02 16:11:02,414 - synapse_ldap_password_provider - 421 - DEBUG - POST-300- LDAP connection in search mode: ldap://bbgroup.local:389 - cleartext - user: jabber_user@bbgroup.local - not lazy - unbound - closed - <no socket> - tls not started - not listening - SyncStrategy - internal decoder
2017-06-02 16:11:05,127 - synapse_ldap_password_provider - 454 - DEBUG - - LDAP search filter: (&(sAMAccountName=matrix)(objectCategory=person))
2017-06-02 16:11:05,129 - synapse_ldap_password_provider - 471 - DEBUG - - LDAP search found dn: CN=matrix,OU=BBGROUP,DC=bbgroup,DC=local
2017-06-02 16:11:05,130 - synapse_ldap_password_provider - 368 - DEBUG - - LDAP connection in simple bind mode: ldap://bbgroup.local:389 - cleartext - user: CN=matrix,OU=BBGROUP,DC=bbgroup,DC=local - not lazy - unbound - closed - <no socket> - tls not started - not listening - SyncStrategy - internal decoder
2017-06-02 16:11:05,131 - synapse_ldap_password_provider - 454 - DEBUG - - LDAP search filter: (&(sAMAccountName=dv_ryabyy)(objectCategory=person))
2017-06-02 16:11:05,134 - synapse_ldap_password_provider - 471 - DEBUG - - LDAP search found dn: CN=Ð ÑÐ±ÑÐ¹ ÐÐµÐ½Ð¸Ñ ÐÐ°Ð»ÐµÑÑÐµÐ²Ð¸Ñ,OU=ÐÑÐ´ÐµÐ» ÑÐµÑÐµÐ²Ð¾Ð³Ð¾ Ð¸ ÑÐ¸ÑÑÐµÐ¼Ð½Ð¾Ð³Ð¾ Ð°Ð´Ð¼Ð¸Ð½Ð¸ÑÑÑÐ¸ÑÐ¾Ð²Ð°Ð½Ð¸Ñ,OU=ÐÐµÐ¿Ð°ÑÑÐ°Ð¼ÐµÐ½Ñ Ð¸Ð½Ñ
                          Ð¾ÑÐ¼Ð°ÑÐ¸Ð¾Ð½Ð½ÑÑ
 ÑÐµÑ
Ð½Ð¾Ð»Ð¾Ð³Ð¸Ð¹,OU=ÐÐ¸Ð½Ð³Ð¾ ÐÑÐ¼,OU=BBGROUP,DC=bbgroup,DC=local
2017-06-02 16:11:05,145 - synapse_ldap_password_provider - 381 - DEBUG - - LDAP Bind successful in simple bind mode.
2017-06-02 16:11:05,146 - synapse_ldap_password_provider - 133 - DEBUG - - LDAP auth method authenticated search returned: True (conn: ldap://bbgroup.local:389 - cleartext - user: CN=matrix,OU=BBGROUP,DC=bbgroup,DC=local - not lazy - bound - open - <local: 172.17.0.6:33936 - remote: 10.192.1.90:389> - tls not started - listening - SyncStrategy - internal decoder)
2017-06-02 16:11:05,146 - synapse_ldap_password_provider - 176 - DEBUG - - LDAP search filter: (&(sAMAccountName=matrix)(objectCategory=person))
2017-06-02 16:11:05,150 - synapse_ldap_password_provider - 133 - DEBUG - - LDAP auth method authenticated search returned: False (conn: None)
```

So we need to encode it with utf-8