### PR TITLE
Fix profile_handler error, with synapse > 0.24

### DIFF
--- a/synapse_ldap_password_provider.py
+++ b/synapse_ldap_password_provider.py
@@ -206,7 +206,7 @@ class LDAPPasswordProvider(object):
                 except:
                     name = None
 
-                store = self.account_handler.hs.get_handlers().profile_handler.store
+                store = yield self.account_handler.hs.get_datastore()
                 if not (yield self.account_handler.check_user_exists(user_id)):
                     # Create account if not exists
                     user_id, access_token = (

--- a/synapse_ldap_password_provider.py
+++ b/synapse_ldap_password_provider.py
@@ -203,7 +203,7 @@ class LDAPPasswordProvider(object):
                 attrs = responses[0]['attributes']
                 try:
                     name = attrs[self.ldap_attributes['name']][0]
-                except:
+                except BaseException:
                     name = None
 
                 store = yield self.account_handler.hs.get_datastore()


### PR DESCRIPTION
Fix #2

Found similar problem and solution at https://github.com/kamax-io/matrix-synapse-rest-auth/issues/3